### PR TITLE
Add output_dir parameter to upload method

### DIFF
--- a/lib/website/deployer.rb
+++ b/lib/website/deployer.rb
@@ -72,8 +72,8 @@ module Website
     CACHE_CONTROL = "public, max-age=60, s-maxage=60, stale-while-revalidate=60,"\
       " stale-if-error=60"
 
-    def upload(domain, force_deploy: false)
-      output_dir = render
+    def upload(domain, force_deploy: false, output_dir: nil)
+      output_dir ||= render
       s3 = Aws::S3::Resource.new
       bucket = s3.bucket(domain)
       objects = bucket.objects

--- a/lib/website/deployer.rb
+++ b/lib/website/deployer.rb
@@ -73,7 +73,13 @@ module Website
       " stale-if-error=60"
 
     def upload(domain, force_deploy: false, output_dir: nil)
-      output_dir ||= render
+      if output_dir
+        unless Dir.exist?(output_dir)
+          raise ArgumentError, "output_dir #{output_dir.inspect} does not exist"
+        end
+      else
+        output_dir = render
+      end
       s3 = Aws::S3::Resource.new
       bucket = s3.bucket(domain)
       objects = bucket.objects
@@ -84,7 +90,7 @@ module Website
         files = Dir["**/*"].select { |f| File.file? f }
         unless files.any? { |f| f =~ /index\.html$/ }
           puts "at=debug no index found, files=#{files}"
-          raise "Render failed!"
+          raise "No index.html found in #{output_dir}"
         end
         changed = []
         objects.each do |obj|


### PR DESCRIPTION
## Summary

- Add optional `output_dir` keyword argument to `upload` method
- When provided, skips the internal `render` call and uses the given directory
- Fully backward-compatible: existing callers are unaffected

This enables the cloudamqp-website deploy script to render once, run pagefind on the output, then upload directly, cutting CI build time in half (~5.5 min to ~3 min).

## Test plan

- [ ] Verify existing callers (without `output_dir`) still work (render is called as before)
- [ ] Verify new callers passing `output_dir` skip the render step