### PR TITLE
Support CLOUDFRONT_DISTRIBUTION_ID env var

### DIFF
--- a/lib/website/deployer.rb
+++ b/lib/website/deployer.rb
@@ -72,8 +72,8 @@ module Website
     CACHE_CONTROL = "public, max-age=60, s-maxage=60, stale-while-revalidate=60,"\
       " stale-if-error=60"
 
-    def upload(domain, force_deploy: false)
-      output_dir = render
+    def upload(domain, force_deploy: false, output_dir: nil)
+      output_dir ||= render
       s3 = Aws::S3::Resource.new
       bucket = s3.bucket(domain)
       objects = bucket.objects

--- a/lib/website/deployer.rb
+++ b/lib/website/deployer.rb
@@ -153,33 +153,45 @@ module Website
 
     def invalidate_cf(domain, changed, force_deploy)
       return if changed.empty? && !force_deploy
+
+      cf_distribution_id = resolve_distribution_id(domain)
+      unless cf_distribution_id
+        puts "Couldn't find a CloudFront distribution for #{domain}"
+        return
+      end
+
+      cf = Aws::CloudFront::Client.new
+      resp = cf.create_invalidation(
+        distribution_id: cf_distribution_id,
+        invalidation_batch: {
+          paths: {
+            items: force_deploy ? ["/*"] : changed,
+            quantity: force_deploy ? 1 : changed.length,
+          },
+          caller_reference: SecureRandom.uuid,
+        }
+      )
+      puts "Invalidating #{changed.length} changed items on CloudFront #{cf_distribution_id}"
+      cf.wait_until(:invalidation_completed, {
+        distribution_id: cf_distribution_id,
+        id: resp.invalidation.id
+      }, {
+        before_wait: lambda do |attempts, _response|
+          puts "Waiting for CF invalidation (#{attempts})"
+        end
+      })
+      puts "Done!"
+    end
+
+    def resolve_distribution_id(domain)
+      if (id = ENV["CLOUDFRONT_DISTRIBUTION_ID"])
+        return id
+      end
+
       cf = Aws::CloudFront::Resource.new
       dists = cf.client.list_distributions.distribution_list.items
       dist = dists.find { |d| d[:aliases][:items].include? domain }
-      if dist && cf_distribution_id = dist[:id]
-        resp = cf.client.create_invalidation(
-          distribution_id: cf_distribution_id,
-          invalidation_batch: {
-            paths: {
-              items: force_deploy ? ["/*"] : changed,
-              quantity: force_deploy ? 1 : changed.length,
-            },
-            caller_reference: SecureRandom.uuid,
-          }
-        )
-        puts "Invalidating #{changed.length} changed items on CloudFront #{cf_distribution_id}"
-        cf.client.wait_until(:invalidation_completed, {
-          distribution_id: cf_distribution_id,
-          id: resp.invalidation.id
-        }, {
-          before_wait: lambda do |attempts, _response|
-            puts "Waiting for CF invalidation (#{attempts})"
-          end
-        })
-        puts "Done!"
-      else
-        puts "Couldn't find a CloudFront distribution for #{domain}"
-      end
+      dist&.dig(:id)
     end
 
     def random_free_port(host)


### PR DESCRIPTION
## Summary

- When `CLOUDFRONT_DISTRIBUTION_ID` is set, uses it directly for cache invalidation instead of calling `ListDistributions`
- Falls back to the existing domain-based lookup when unset (no change for cloudmqtt, cloudkarafka, elephantsql)

The `ListDistributions` call requires broad IAM permissions (`cloudfront:ListDistributions` on `*`). The cloudamqp-website IAM role only grants scoped permissions on specific distributions, causing intermittent `AccessDenied` failures on deploy.

## Test plan

- [ ] Deploy cloudamqp-website with `CLOUDFRONT_DISTRIBUTION_ID` set and verify invalidation works
- [ ] Verify other website repos still deploy without the env var set